### PR TITLE
enable eccentric model for the pycbc plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@
 [project.entry-points."pycbc.waveform.td"]
     SEOBNRv5HM  = "pyseobnr.plugins.pycbc_plugin:PySEOBNRv5PyCBCPlugin_v5HM.gen_td"
     SEOBNRv5PHM = "pyseobnr.plugins.pycbc_plugin:PySEOBNRv5PyCBCPlugin_v5PHM.gen_td"
+    SEOBNRv5EHM = "pyseobnr.plugins.pycbc_plugin:PySEOBNRv5PyCBCPlugin_v5EHM.gen_td"
 
 [project.entry-points."pycbc.waveform.fd"]
     SEOBNRv5HM  = "pyseobnr.plugins.pycbc_plugin:PySEOBNRv5PyCBCPlugin_v5HM.gen_fd"

--- a/pyseobnr/plugins/pycbc_plugin.py
+++ b/pyseobnr/plugins/pycbc_plugin.py
@@ -76,6 +76,10 @@ class PySEOBNRv5PyCBCPlugin:
         return hp, hc
 
 
+class PySEOBNRv5PyCBCPlugin_v5EHM(PySEOBNRv5PyCBCPlugin):
+    approximant = "SEOBNRv5EHM"
+
+
 class PySEOBNRv5PyCBCPlugin_v5HM(PySEOBNRv5PyCBCPlugin):
     approximant = "SEOBNRv5HM"
 


### PR DESCRIPTION
Sending this here as the gitlab is not accessible to those not in the LVK. 

This enables the pycbc plugin to use the eccentric model. 
