### PR TITLE
fix tc alignment for fd waveforms in pycbc plugin

### DIFF
--- a/pyseobnr/plugins/pycbc_plugin.py
+++ b/pyseobnr/plugins/pycbc_plugin.py
@@ -73,6 +73,10 @@ class PySEOBNRv5PyCBCPlugin:
         hp = FrequencySeries(hp.data.data[:], delta_f=hp.deltaF, epoch=hp.epoch)
         hc = FrequencySeries(hc.data.data[:], delta_f=hc.deltaF, epoch=hp.epoch)
 
+        # Align the pyseobnr time convention so that the waveform peak occurs at t=0
+        hp = hp.cyclic_time_shift(hp.start_time + hp.duration)
+        hc = hc.cyclic_time_shift(hc.start_time + hc.duration)
+
         return hp, hc
 
 


### PR DESCRIPTION
This PR fixes the time of coalescence (t_c) alignment for frequency-domain (FD) waveforms returned through the PyCBC plugin. The current implementation introduces a mismatch between the expected and actual peak time of the waveform. This change corrects the time offset by shifting the waveform so that its peak occurs at t = 0. 

